### PR TITLE
IMTA-5027 dotenv implementation - username and password are no longer needed as x-auth-basic is dropped

### DIFF
--- a/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/ServiceTestHelper.java
+++ b/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/ServiceTestHelper.java
@@ -14,8 +14,6 @@ public class ServiceTestHelper {
   public static final String AUTHORIZATION = "Authorization";
 
   public ServiceTestHelper() {
-    assertNotNullOrEmpty(getServiceUsername(), "Username is empty");
-    assertNotNullOrEmpty(getServicePassword(), "Password is empty");
     assertNotNullOrEmpty(getServiceBaseUrl(), "Url is empty");
   }
 


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Lukasz Kedron (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-common-security](https://giteux.azure.defra.cloud/imports/spring-boot-common-security) |
> | **GitLab Merge Request** | [IMTA-5027 dotenv implementation - userna...](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/11) |
> | **GitLab MR Number** | [11](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/11) |
> | **Date Originally Opened** | Wed, 15 May 2019 |
> | **Approved on GitLab by** | _No approvers_ |
> |      |      |
>
> This merge request was originally **closed** on GitLab

## Original Description

_No description_