### PR TITLE
IMTA:8976 - OWASP high upgrade versions

### DIFF
--- a/common-security-tests/src/test/java/uk/gov/defra/tracesx/common/security/tests/jwt/EmptyTest.java
+++ b/common-security-tests/src/test/java/uk/gov/defra/tracesx/common/security/tests/jwt/EmptyTest.java
@@ -1,0 +1,12 @@
+package uk.gov.defra.tracesx.common.security.tests.jwt;
+
+import org.junit.Test;
+
+public class EmptyTest {
+
+  @Test
+  public void avoidJenkinsEmptyTestError() {
+    String keepJenkinsHappy = "avoid hudson.AbortException: No test report files were found. Configuration error?";
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -81,6 +81,12 @@
         <groupId>com.auth0</groupId>
         <artifactId>jwks-rsa</artifactId>
         <version>${jwks.rsa.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>io.jsonwebtoken</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-dependencies</artifactId>
-    <version>2.1.9.RELEASE</version>
+    <version>2.4.2</version>
   </parent>
 
   <properties>
@@ -21,18 +21,14 @@
     <maven.compiler.target>${java.version}</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <!-- Spring Boot dependency version overrides -->
-    <jackson.version>2.10.1</jackson.version>
-    <!-- End Spring Boot dependency version overrides -->
-
     <applicationinsights.version>2.5.0</applicationinsights.version>
     <checkstyle.version>3.0.0</checkstyle.version>
     <javax.el.version>3.0.0</javax.el.version>
     <jjwt.version>0.10.5</jjwt.version>
-    <jwks.rsa.version>0.3.0</jwks.rsa.version>
+    <jwks.rsa.version>0.9.0</jwks.rsa.version>
     <nimbus.version>6.8</nimbus.version>
-    <rest-assured.version>3.3.0</rest-assured.version>
-    <spring.security.jwt.version>1.0.10.RELEASE</spring.security.jwt.version>
+    <rest-assured.version>4.3.3</rest-assured.version>
+    <spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
     <jacoco.maven.plugin.version>0.8.4</jacoco.maven.plugin.version>
   </properties>
 
@@ -66,6 +62,19 @@
         <groupId>org.springframework.security</groupId>
         <artifactId>spring-security-jwt</artifactId>
         <version>${spring.security.jwt.version}</version>
+        <!-- avoid OWASP guava version issue -->
+        <exclusions>
+          <exclusion>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <!-- avoid OWASP guava version issue -->
+      <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>30.1-jre</version>
       </dependency>
       <!-- used to fetch public signing keys from jwks urls -->
       <dependency>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | bridget.hodgson (Kainos) |
> | **GitLab Project** | [imports/spring-boot-common-security](https://giteux.azure.defra.cloud/imports/spring-boot-common-security) |
> | **GitLab Merge Request** | [IMTA:8976 - OWASP high upgrade versions](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/34) |
> | **GitLab MR Number** | [34](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/34) |
> | **Date Originally Opened** | Thu, 21 Jan 2021 |
> | **Approved on GitLab by** | Reece Bennett (KAINOS), Stephen Donaghey (KAINOS), dominik henjes (KAINOS), lee mason (KAINOS), marcus bond (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

* https://eaflood.atlassian.net/browse/IMTA-8976
* The services use the versions of many of the jars that are defined in this project.
* Upgrading the versions here and will then apply it to the services once merged.
* Jenkins build was failing as there was no surefire report as there were no tests in one of the sub modules.  This is because it is a test dependancy and there are no tests to test the tests.  Added an empty JUnit test to resolve this.