### PR TITLE
IMTA-9218: Assign display name to correct claim

### DIFF
--- a/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/jwt/JwtUserMapper.java
+++ b/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/jwt/JwtUserMapper.java
@@ -23,6 +23,8 @@ public class JwtUserMapper {
   private static final String CUSTOMER_ID = "customer_id";
   private static final String CUSTOMER_ORGANISATION_ID = "customer_organisation_id";
   private static final String CENTRAL_COMPETENT_AUTHORITY = "cca";
+  private static final String FAMILY_NAME = "family_name";
+  private static final String GIVEN_NAME = "given_name";
 
   private final RoleToAuthorityMapper roleToAuthorityMapper;
 
@@ -34,7 +36,8 @@ public class JwtUserMapper {
   public IdTokenUserDetails createUser(Map<String, Object> decoded, String idToken) {
     return IdTokenUserDetails.builder()
         .idToken(idToken)
-        .displayName(getClaim(SUB, decoded, true))
+        .displayName(getClaim(GIVEN_NAME, decoded, true) + " "
+            + getClaim(FAMILY_NAME, decoded, true))
         .username(getClaim(SUB, decoded, true))
         .userObjectId(getClaim(SUB, decoded, true))
         .customerId(getClaim(CUSTOMER_ID, decoded, false))

--- a/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/filter/JwtTokenFilterComponentTest.java
+++ b/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/filter/JwtTokenFilterComponentTest.java
@@ -12,6 +12,8 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.defra.tracesx.common.security.jwt.MockJwks.CENTRAL_COMPETENT_AUTHORITY;
+import static uk.gov.defra.tracesx.common.security.jwt.MockJwks.FAMILY_NAME;
+import static uk.gov.defra.tracesx.common.security.jwt.MockJwks.GIVEN_NAME;
 import static uk.gov.defra.tracesx.common.security.jwt.MockJwks.JWK1;
 import static uk.gov.defra.tracesx.common.security.jwt.MockJwks.JWK2;
 import static uk.gov.defra.tracesx.common.security.jwt.MockJwks.JWKS_AUDIENCE1;
@@ -160,7 +162,7 @@ public class JwtTokenFilterComponentTest {
     assertThat(authentication.getDetails()).isInstanceOf(IdTokenUserDetails.class);
     IdTokenUserDetails details = (IdTokenUserDetails) authentication.getDetails();
     assertThat(details.getUserObjectId()).isEqualTo(SUB_VALUE);
-    assertThat(details.getDisplayName()).isEqualTo(SUB_VALUE);
+    assertThat(details.getDisplayName()).isEqualTo(GIVEN_NAME + " " + FAMILY_NAME);
     assertThat(details.getUsername()).isEqualTo(SUB_VALUE);
     assertThat(details.getPassword()).isNull();
     assertThat(details.getAuthorities()).containsOnlyElementsOf((Iterable) EXPECTED_AUTHORITIES);

--- a/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/jwt/JwtUserMapperTest.java
+++ b/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/jwt/JwtUserMapperTest.java
@@ -30,7 +30,8 @@ public class JwtUserMapperTest {
   private JwtUserMapper jwtUserMapper = new JwtUserMapper(roleToAuthorityMapper);
 
   private static final String USER_OBJECT_ID = "e9f6447d-2979-4322-8e52-307dafdef649";
-  private static final String DISPLAY_NAME = "Joseph William Token";
+  private static final String FAMILY_NAME = "Token";
+  private static final String GIVEN_NAME = "Joseph William";
   private static final String USERNAME = "jtoken@tenant.com";
   private static final String ID_TOKEN = "adfgsdf.dfgsdrgerg.dfgdfgd";
   private static final String SUB = "e9f6447d-2979-4322-8e52-307dafdef649";
@@ -47,7 +48,8 @@ public class JwtUserMapperTest {
     decoded.put("sub", SUB);
     decoded.put("roles", ROLES);
     decoded.put("oid", USER_OBJECT_ID);
-    decoded.put("name", DISPLAY_NAME);
+    decoded.put("family_name", FAMILY_NAME);
+    decoded.put("given_name", GIVEN_NAME);
     decoded.put("upn", USERNAME);
     decoded.put("customer_id", CUSTOMER_ID);
     decoded.put("customer_organisation_id", ORG_ID);
@@ -60,7 +62,7 @@ public class JwtUserMapperTest {
         .idToken(ID_TOKEN)
         .authorities(AUTHORITIES)
         .userObjectId(SUB)
-        .displayName(SUB)
+        .displayName(GIVEN_NAME + " " + FAMILY_NAME)
         .username(SUB)
         .customerOrganisationId(null)
         .customerId(CUSTOMER_ID)
@@ -76,7 +78,7 @@ public class JwtUserMapperTest {
         .idToken(ID_TOKEN)
         .authorities(AUTHORITIES)
         .userObjectId(SUB)
-        .displayName(SUB)
+        .displayName(GIVEN_NAME + " " + FAMILY_NAME)
         .username(SUB)
         .customerOrganisationId(ORG_ID)
         .customerId(CUSTOMER_ID)

--- a/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/jwt/MockJwks.java
+++ b/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/jwt/MockJwks.java
@@ -33,6 +33,9 @@ public class MockJwks {
   public static final String CENTRAL_COMPETENT_AUTHORITY = "DEFRA";
   public static final List<String> ROLES_VALUE = Collections.singletonList("ROLE1");
 
+  public static final String FAMILY_NAME = "Token";
+  public static final String GIVEN_NAME = "Joseph William";
+
   public static final RSAKey NIMBUS_KEY1 = createNimbusKey();
   public static final KeyPair KEY_PAIR1 = toKeyPair(NIMBUS_KEY1);
   public static final JwkElement JWK_ELEMENT1 = createJwkElement(NIMBUS_KEY1);
@@ -68,6 +71,8 @@ public class MockJwks {
         .claim("aud", JWKS_AUDIENCE1)
         .claim("iss", JWKS_ISSUER1)
         .claim("sub", SUB_VALUE)
+        .claim("family_name", FAMILY_NAME)
+        .claim("given_name", GIVEN_NAME)
         .claim("roles", ROLES_VALUE)
         .claim("customer_organisation_id", ORG_ID)
         .claim("cca", CENTRAL_COMPETENT_AUTHORITY)
@@ -82,6 +87,8 @@ public class MockJwks {
         .claim("aud", JWKS_AUDIENCE2)
         .claim("iss", JWKS_ISSUER2)
         .claim("sub", SUB_VALUE)
+        .claim("family_name", FAMILY_NAME)
+        .claim("given_name", GIVEN_NAME)
         .claim("roles", ROLES_VALUE)
         .claim("customer_organisation_id", ORG_ID)
         .signWith(KEY_PAIR2.getPrivate())


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Popa, Paul (Kainos) |
> | **GitLab Project** | [imports/spring-boot-common-security](https://giteux.azure.defra.cloud/imports/spring-boot-common-security) |
> | **GitLab Merge Request** | [IMTA-9218: Assign display name to correc...](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/36) |
> | **GitLab MR Number** | [36](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/36) |
> | **Date Originally Opened** | Thu, 18 Mar 2021 |
> | **Approved on GitLab by** | Blakeley, Paul (Kainos), Callum Atwal (kainos), Juliano Saunders (Kainos), Marina Tihova (Kainos), Nicholas Martin, kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Changed the `displayName` field to contain data of the `given_name` and `family_name` from the claims

**JIRA ticket**: https://eaflood.atlassian.net/browse/IMTA-9218

**Background**: When a notification is created via the notification-microservice, the `lastUpdatedBy` field does not get populated with the user that created the notification.