### PR TITLE
IMTA-12100: Publish spring boot common security code in the open

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,8 @@
+The Open Government Licence (OGL) Version 3
+
+Copyright (c) 2021 Defra
+
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,18 @@ and a client for calling the permissions service.
 This module should be included as a test dependency of the integration tests for any service using
 `common-security-config`. It includes two abstract test classes that must be extended to verify security
 is working correctly in the service.
+
+## Secret scanning
+Secret scanning is setup using [truffleHog](https://github.com/trufflesecurity/truffleHog).
+It is used as a pre-push hook and will scan any local commits being pushed
+
+### Pre-push hook setup
+1. Install [truffleHog](https://github.com/trufflesecurity/truffleHog)
+    - `brew install go`
+    - `git clone https://github.com/trufflesecurity/trufflehog.git`
+    - `cd trufflehog; go install`
+2. Set DEFRA_WORKSPACE env var (`export DEFRA_WORKSPACE=/path/to/workspace`)
+3. Potentially there's an older version of Trufflehog located at: `/usr/local/bin/trufflehog`. If so, remove this.
+4. Create a symlink: `ln -s ~/go/bin/truffleHog /usr/local/bin/trufflehog`
+5. From this project root directory copy the pre-push hook: `cp hooks/pre-push .git/hooks/pre-push`
+6. If you don't see trufflehog running upon pushing or see a warning that looks like `The '.git/hooks/pre-push' hook was ignored because it's not set as executable.`, make the hook file executable by running `chmod +x .git/hooks/pre-push`.

--- a/common-security-config/LICENSE
+++ b/common-security-config/LICENSE
@@ -1,0 +1,8 @@
+The Open Government Licence (OGL) Version 3
+
+Copyright (c) 2021 Defra
+
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/common-security-tests/LICENSE
+++ b/common-security-tests/LICENSE
@@ -1,0 +1,8 @@
+The Open Government Licence (OGL) Version 3
+
+Copyright (c) 2021 Defra
+
+This source code is licensed under the Open Government Licence v3.0. To view this
+licence, visit www.nationalarchives.gov.uk/doc/open-government-licence/version/3
+or write to the Information Policy Team, The National Archives, Kew, Richmond,
+Surrey, TW9 4DU.

--- a/hooks/pre-push
+++ b/hooks/pre-push
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+RED='\033[0;31m'
+NO_COLOUR='\033[0m'
+LOG_PREFIX="Pre-push hook:"
+FAILED_MESSAGE="${LOG_PREFIX} ${RED}[FAILED]${NO_COLOUR}"
+REPO_NAME="spring-boot-common-security"
+
+trufflehog --help > /dev/null 2>&1 || { echo -e "${FAILED_MESSAGE} truffleHog is not installed. Please install via https://github.com/trufflesecurity/truffleHog" ; exit 1; }
+[ -z "$DEFRA_WORKSPACE" ] && echo -e "${FAILED_MESSAGE} Please set DEFRA_WORKSPACE env var to your Defra workspace" && exit 1;
+
+echo "${LOG_PREFIX} RUNNING truffleHog to test for leaked secrets."
+trufflehog git --fail --regex --since_commit "$(git rev-parse origin/HEAD)" --branch "$(git rev-parse --abbrev-ref HEAD)" file://"${DEFRA_WORKSPACE}"/${REPO_NAME}
+exit_code=$?
+
+if [[ $exit_code -ne 0 ]]; then
+  echo -e "${FAILED_MESSAGE} truffleHog found some suspicious commits containing possible secrets"
+  echo -e "${FAILED_MESSAGE} git push failed, Please remove the secrets caught by truffleHog"
+  exit 1
+else
+  echo "${LOG_PREFIX} OK proceeding with push"
+  exit 0
+fi

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <rest-assured.version>4.3.3</rest-assured.version>
     <spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
     <jacoco.maven.plugin.version>0.8.4</jacoco.maven.plugin.version>
-    <owasp.version>6.0.5</owasp.version>
+    <owasp.version>6.5.3</owasp.version>
   </properties>
 
   <scm>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Ben Doherty (Kainos) |
> | **GitLab Project** | [imports/spring-boot-common-security](https://giteux.azure.defra.cloud/imports/spring-boot-common-security) |
> | **GitLab Merge Request** | [IMTA-12100: Publish spring boot common s...](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/40) |
> | **GitLab MR Number** | [40](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/40) |
> | **Date Originally Opened** | Fri, 1 Jul 2022 |
> | **Approved on GitLab by** | Jahir, Sifat (KAINOS), Nicholas Martin, Thomas Seelig (Kainos), lee mason (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-12100)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=feature%2FIMTA-12100-code-in-the-open&id=Imports-SpringBoot-CommonSecurity)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-common-security/job/feature%2FIMTA-12100-code-in-the-open/)

### :book: Changes:
* Add secret scanning
* Add git hook
* Update README
* Bump OWASP version in pom for consistency in dependency reporting with Jenkins