### PR TITLE
IMTA-13298: Improve JWT validation

### DIFF
--- a/common-security-config/pom.xml
+++ b/common-security-config/pom.xml
@@ -47,10 +47,10 @@
       <groupId>com.microsoft.azure</groupId>
       <artifactId>applicationinsights-web</artifactId>
     </dependency>
-    <!-- used to decode and validate jwt tokens -->
+    <!-- used to decode and validate jwt tokens / also used in component testing -->
     <dependency>
-      <groupId>org.springframework.security</groupId>
-      <artifactId>spring-security-jwt</artifactId>
+      <groupId>com.nimbusds</groupId>
+      <artifactId>nimbus-jose-jwt</artifactId>
     </dependency>
     <!-- used to fetch public signing keys from jwks urls -->
     <dependency>
@@ -107,12 +107,6 @@
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
       <artifactId>jjwt-jackson</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <!-- nimbus is needed to create the jwks used for component testing -->
-    <dependency>
-      <groupId>com.nimbusds</groupId>
-      <artifactId>nimbus-jose-jwt</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/filter/JwtTokenFilterComponentTest.java
+++ b/common-security-config/src/test/java/uk/gov/defra/tracesx/common/security/filter/JwtTokenFilterComponentTest.java
@@ -72,7 +72,6 @@ public class JwtTokenFilterComponentTest {
   private JwksCache jwksCache;
   private List<JwksConfiguration> jwksConfigurations;
   private SpyableJwkProviderFactory jwkProviderFactory;
-  private ObjectMapper objectMapper = new ObjectMapper();
 
   private JwksConfiguration jwksConfiguration1;
   private JwksConfiguration jwksConfiguration2;
@@ -114,7 +113,7 @@ public class JwtTokenFilterComponentTest {
     doReturn(jwkProvider2).when(jwkProviderFactory).createUrlJwkProvider(eq(new URL(JWKS_URL2)));
 
     jwksCache = spy(new JwksCache(jwksConfigurations, jwkProviderFactory));
-    jwtTokenValidator = new JwtTokenValidator(jwtUserMapper, jwksCache, objectMapper);
+    jwtTokenValidator = new JwtTokenValidator(jwtUserMapper, jwksCache);
     jwtTokenFilter = new JwtTokenFilter("/url", jwtTokenValidator);
 
     request = mock(HttpServletRequest.class);

--- a/pom.xml
+++ b/pom.xml
@@ -26,9 +26,8 @@
     <javax.el.version>3.0.0</javax.el.version>
     <jjwt.version>0.10.5</jjwt.version>
     <jwks.rsa.version>0.13.0</jwks.rsa.version>
-    <nimbus.version>6.8</nimbus.version>
+    <nimbus.version>9.30.2</nimbus.version>
     <rest-assured.version>4.3.3</rest-assured.version>
-    <spring.security.jwt.version>1.1.1.RELEASE</spring.security.jwt.version>
     <jacoco.maven.plugin.version>0.8.4</jacoco.maven.plugin.version>
     <owasp.version>7.1.1</owasp.version>
   </properties>
@@ -57,12 +56,6 @@
         <groupId>com.microsoft.azure</groupId>
         <artifactId>applicationinsights-web</artifactId>
         <version>${applicationinsights.version}</version>
-      </dependency>
-      <!-- used to decode and validate jwt tokens -->
-      <dependency>
-        <groupId>org.springframework.security</groupId>
-        <artifactId>spring-security-jwt</artifactId>
-        <version>${spring.security.jwt.version}</version>
       </dependency>
       <!-- avoid OWASP guava version issue -->
       <dependency>


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | Marina Tihova |
> | **GitLab Project** | [imports/spring-boot-common-security](https://giteux.azure.defra.cloud/imports/spring-boot-common-security) |
> | **GitLab Merge Request** | [IMTA-13298: Improve JWT validation](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/43) |
> | **GitLab MR Number** | [43](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/43) |
> | **Date Originally Opened** | Fri, 17 Feb 2023 |
> | **Approved on GitLab by** | Apurva Jhunjhunwala (Kainos), Eugene Fahy (Kainos), Reece Bennett (KAINOS), kamil mojek (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

### :link: [Jira Ticket](https://eaflood.atlassian.net/browse/IMTA-13298)

### :chart_with_upwards_trend: [SonarQube Report](https://vss-sonarqube.azure.defra.cloud/dashboard?branch=bugfix%2FIMTA-13298-invalid-jwt-should-return-401&id=Imports-SpringBoot-CommonSecurity)

### :building_construction: [Jenkins Pipeline](https://jenkins-imports.azure.defra.cloud/job/spring-boot-common-security/job/bugfix%2FIMTA-13298-invalid-jwt-should-return-401/)

### :book: Changes:
- switch to `nimbus-jose-jwt` library from deprecated `spring-security-jwt` for parsing and validating JWTs
- improve JWT validator
- update unit tests