### PR TITLE
MTA-4763: Refactor of common security to remove the need to configure API http…

### DIFF
--- a/common-security-config/src/main/java/uk/gov/defra/tracesx/common/CommonWebMvcConfiguration.java
+++ b/common-security-config/src/main/java/uk/gov/defra/tracesx/common/CommonWebMvcConfiguration.java
@@ -37,10 +37,10 @@ public class CommonWebMvcConfiguration implements WebMvcConfigurer {
 
   private static final String DEFAULT_PERMISSIONS_TIMEOUT_MILLIS = "25000";
 
-  @Value("${permissions.service.connectionTimeout:"+DEFAULT_PERMISSIONS_TIMEOUT_MILLIS+"}")
+  @Value("${permissions.service.connectionTimeout:" + DEFAULT_PERMISSIONS_TIMEOUT_MILLIS + "}")
   private int permissionsServiceConnectionTimeout;
 
-  @Value("${permissions.service.readTimeout:"+DEFAULT_PERMISSIONS_TIMEOUT_MILLIS+"}")
+  @Value("${permissions.service.readTimeout:" + DEFAULT_PERMISSIONS_TIMEOUT_MILLIS + "}")
   private int permissionsServiceReadTimeout;
 
   @Value("${spring.security.jwt.jwks}")
@@ -52,21 +52,19 @@ public class CommonWebMvcConfiguration implements WebMvcConfigurer {
   @Value("${spring.security.jwt.aud}")
   private String aud;
 
-  @Autowired
-  private ServiceUrlPatterns serviceUrlPatterns;
+  @Autowired private ServiceUrlPatterns serviceUrlPatterns;
 
   @Override
   public void addInterceptors(InterceptorRegistry registry) {
-    registry.addInterceptor(new PreAuthorizeChecker())
-        .addPathPatterns(serviceUrlPatterns.getPatterns());
+    registry
+        .addInterceptor(new PreAuthorizeChecker())
+        .addPathPatterns(serviceUrlPatterns.getAuthorizedPatterns());
   }
 
   @Bean
   @Qualifier(PERMISSIONS_REST_TEMPLATE_QUALIFIER)
   public RestTemplate permissionsRestTemplate() {
-    return createRestTemplate(
-        permissionsServiceConnectionTimeout,
-        permissionsServiceReadTimeout);
+    return createRestTemplate(permissionsServiceConnectionTimeout, permissionsServiceReadTimeout);
   }
 
   @Bean
@@ -76,16 +74,19 @@ public class CommonWebMvcConfiguration implements WebMvcConfigurer {
     String[] issuers = iss.split(",");
     String[] audiences = aud.split(",");
     List<JwksConfiguration> jwksConfigurations = new ArrayList<>();
-    if(jwkUrls.length == issuers.length && issuers.length == audiences.length) {
-      for(int i = 0; i < jwkUrls.length; i++) {
-        jwksConfigurations.add(JwksConfiguration.builder()
-            .jwksUrl(new URL(jwkUrls[i]))
-            .issuer(issuers[i])
-            .audience(audiences[i]).build());
+    if (jwkUrls.length == issuers.length && issuers.length == audiences.length) {
+      for (int i = 0; i < jwkUrls.length; i++) {
+        jwksConfigurations.add(
+            JwksConfiguration.builder()
+                .jwksUrl(new URL(jwkUrls[i]))
+                .issuer(issuers[i])
+                .audience(audiences[i])
+                .build());
       }
       return Collections.unmodifiableList(jwksConfigurations);
     } else {
-      throw new RuntimeException("The comma-separated properties spring.security.jwt.[jwks, iss, aud] must all have the same number of elements.");
+      throw new RuntimeException(
+          "The comma-separated properties spring.security.jwt.[jwks, iss, aud] must all have the same number of elements.");
     }
   }
 
@@ -103,12 +104,12 @@ public class CommonWebMvcConfiguration implements WebMvcConfigurer {
   }
 
   private RestTemplate createRestTemplate(int connectionTimeout, int readTimeout) {
-    HttpComponentsClientHttpRequestFactory clientHttpRequestFactory = new HttpComponentsClientHttpRequestFactory();
+    HttpComponentsClientHttpRequestFactory clientHttpRequestFactory =
+        new HttpComponentsClientHttpRequestFactory();
     clientHttpRequestFactory.setConnectTimeout(connectionTimeout);
     clientHttpRequestFactory.setReadTimeout(readTimeout);
     RestTemplate restTemplate = new RestTemplate(clientHttpRequestFactory);
     restTemplate.getMessageConverters().add(new StringHttpMessageConverter());
     return restTemplate;
   }
-
 }

--- a/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/ServiceUrlPatterns.java
+++ b/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/ServiceUrlPatterns.java
@@ -1,14 +1,11 @@
 package uk.gov.defra.tracesx.common.security;
 
-import java.util.Collection;
 import java.util.List;
 
 public interface ServiceUrlPatterns {
   /**
-   * @return a list of patterns matching the urls used by this endpoint
-   * @see org.springframework.boot.web.servlet.FilterRegistrationBean#setUrlPatterns(Collection)
+   * @return a list of patterns that require authorization to be applied by the.
+   * @see uk.gov.defra.tracesx.common.security.PreAuthorizeChecker
    */
-  List<String> getPatterns();
-
-  List<String> getBaseUrl();
+  List<String> getAuthorizedPatterns();
 }

--- a/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/filter/JwtTokenFilter.java
+++ b/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/filter/JwtTokenFilter.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 import uk.gov.defra.tracesx.common.security.IdTokenAuthentication;
 import uk.gov.defra.tracesx.common.security.IdTokenUserDetails;
 import uk.gov.defra.tracesx.common.security.jwt.JwtTokenValidator;
@@ -24,8 +25,15 @@ public class JwtTokenFilter extends StatelessAuthenticationProcessingFilter {
     this.jwtTokenValidator = jwtTokenValidator;
   }
 
+  public JwtTokenFilter(
+      RequestMatcher requiresAuthenticationRequestMatcher, JwtTokenValidator jwtTokenValidator) {
+    super(requiresAuthenticationRequestMatcher);
+    this.jwtTokenValidator = jwtTokenValidator;
+  }
+
   @Override
-  public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res) throws AuthenticationException, IOException, ServletException {
+  public Authentication attemptAuthentication(HttpServletRequest req, HttpServletResponse res)
+      throws AuthenticationException, IOException, ServletException {
     String token = resolveToken(req);
     if (null != token) {
       IdTokenUserDetails userDetails = jwtTokenValidator.validateToken(token);
@@ -43,5 +51,4 @@ public class JwtTokenFilter extends StatelessAuthenticationProcessingFilter {
     }
     return null;
   }
-
 }

--- a/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/filter/StatelessAuthenticationProcessingFilter.java
+++ b/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/filter/StatelessAuthenticationProcessingFilter.java
@@ -11,15 +11,21 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
-public abstract class StatelessAuthenticationProcessingFilter extends
-    AbstractAuthenticationProcessingFilter {
+public abstract class StatelessAuthenticationProcessingFilter
+    extends AbstractAuthenticationProcessingFilter {
 
   protected StatelessAuthenticationProcessingFilter(String defaultFilterProcessesUrl) {
     super(defaultFilterProcessesUrl);
   }
 
-  //Customized version of spring security filter, to remove session state calls and events
+  protected StatelessAuthenticationProcessingFilter(
+      RequestMatcher requiresAuthenticationRequestMatcher) {
+    super(requiresAuthenticationRequestMatcher);
+  }
+
+  // Customized version of spring security filter, to remove session state calls and events
   @Override
   public void doFilter(ServletRequest req, ServletResponse res, FilterChain chain)
       throws IOException, ServletException {
@@ -49,5 +55,4 @@ public abstract class StatelessAuthenticationProcessingFilter extends
 
     chain.doFilter(request, response);
   }
-
 }

--- a/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/jwks/ClaimsAwareJwkProvider.java
+++ b/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/jwks/ClaimsAwareJwkProvider.java
@@ -17,6 +17,7 @@ public class ClaimsAwareJwkProvider extends GuavaCachedJwkProvider {
 
   /**
    * Creates a new cached provider specifying cache size and ttl
+   *
    * @param provider fallback provider to use when jwk is not cached
    * @param size number of jwt to cache
    * @param expiresIn amount of time a jwk will live in the cache
@@ -24,8 +25,13 @@ public class ClaimsAwareJwkProvider extends GuavaCachedJwkProvider {
    * @param issuer the issuer associated with this jwk provider
    * @param audience the audience associated with this jwk provider
    */
-  public ClaimsAwareJwkProvider(JwkProvider provider, long size, long expiresIn,
-      TimeUnit expiresUnit, String issuer, String audience) {
+  public ClaimsAwareJwkProvider(
+      JwkProvider provider,
+      long size,
+      long expiresIn,
+      TimeUnit expiresUnit,
+      String issuer,
+      String audience) {
     super(provider, size, expiresIn, expiresUnit);
     this.issuer = issuer;
     this.audience = audience;

--- a/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/jwt/JwtContants.java
+++ b/common-security-config/src/main/java/uk/gov/defra/tracesx/common/security/jwt/JwtContants.java
@@ -8,7 +8,5 @@ public class JwtContants {
   public static final String UPN = "upn";
   public static final String OID = "oid";
 
-  private JwtContants() {
-
-  }
+  private JwtContants() {}
 }

--- a/common-security-config/src/test/java/uk/gov/defra/tracesx/common/CommonWebMvcConfigurationComponentTest.java
+++ b/common-security-config/src/test/java/uk/gov/defra/tracesx/common/CommonWebMvcConfigurationComponentTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static uk.gov.defra.tracesx.common.CommonWebMvcConfiguration.PERMISSIONS_REST_TEMPLATE_QUALIFIER;
 
 import java.util.Collections;
-import java.util.List;
 import org.apache.http.client.config.RequestConfig;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -23,7 +22,7 @@ import uk.gov.defra.tracesx.common.CommonWebMvcConfigurationComponentTest.Config
 import uk.gov.defra.tracesx.common.security.ServiceUrlPatterns;
 
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes={Config.class, CommonWebMvcConfiguration.class})
+@SpringBootTest(classes = {Config.class, CommonWebMvcConfiguration.class})
 @ActiveProfiles("webmvc-config")
 public class CommonWebMvcConfigurationComponentTest {
 
@@ -36,26 +35,17 @@ public class CommonWebMvcConfigurationComponentTest {
   static class Config {
     @Bean
     public ServiceUrlPatterns serviceUrlPatterns() {
-      return new ServiceUrlPatterns() {
-        @Override
-        public List<String> getPatterns() {
-          return Collections.singletonList("test/**");
-        }
-
-        @Override
-        public List<String> getBaseUrl() {
-          return Collections.singletonList("test/**");
-        }
-      };
+      return () -> Collections.singletonList("test/**");
     }
   }
 
   @Test
   public void permissionRestTemplate_noTimeoutSpecified_defaultsUsedInstead() {
-    HttpComponentsClientHttpRequestFactory factory = (HttpComponentsClientHttpRequestFactory) permissionsRestTemplate.getRequestFactory();
-    RequestConfig requestConfig = (RequestConfig) ReflectionTestUtils.getField(factory, "requestConfig");
+    HttpComponentsClientHttpRequestFactory factory =
+        (HttpComponentsClientHttpRequestFactory) permissionsRestTemplate.getRequestFactory();
+    RequestConfig requestConfig =
+        (RequestConfig) ReflectionTestUtils.getField(factory, "requestConfig");
     assertThat(requestConfig.getConnectTimeout()).isEqualTo(25000);
     assertThat(requestConfig.getSocketTimeout()).isEqualTo(25000);
   }
-
 }

--- a/common-security-config/src/test/java/uk/gov/defra/tracesx/common/MockServiceUrlPatterns.java
+++ b/common-security-config/src/test/java/uk/gov/defra/tracesx/common/MockServiceUrlPatterns.java
@@ -7,15 +7,11 @@ import uk.gov.defra.tracesx.common.security.ServiceUrlPatterns;
 
 public class MockServiceUrlPatterns implements ServiceUrlPatterns {
 
-  public static final List<String> PATTERNS = Collections.unmodifiableList(
-      Arrays.asList("/path1/*", "/path2/*")
-  );
+  public static final List<String> PATTERNS =
+      Collections.unmodifiableList(Arrays.asList("/path1/*", "/path2/*"));
 
   @Override
-  public List<String> getPatterns() {
+  public List<String> getAuthorizedPatterns() {
     return PATTERNS;
   }
-
-  @Override
-  public List<String> getBaseUrl() { return Arrays.asList("/path/*"); }
 }

--- a/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/AbstractAdminAuthenticationTest.java
+++ b/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/AbstractAdminAuthenticationTest.java
@@ -4,48 +4,31 @@ import static io.restassured.RestAssured.given;
 import static uk.gov.defra.tracesx.common.security.tests.Constants.X_AUTH_BASIC;
 import static uk.gov.defra.tracesx.common.security.tests.Constants.X_AUTH_BASIC_VALUE;
 
-import io.restassured.http.ContentType;
 import org.junit.Test;
+
+import io.restassured.http.ContentType;
 
 public abstract class AbstractAdminAuthenticationTest {
 
-  /**
-   * @return the url for the permissions's /admin path (of which /admin/info and /admin/healthcheck are child paths)
-   */
-  protected abstract String getAdminUrl();
+	private ServiceTestHelper serviceTestHelper = new ServiceTestHelper();
 
-  /**
-   * @return the url for the permissions's root path
-   */
-  protected abstract String getRootUrl();
+	protected ServiceTestHelper getServiceTestHelper() {
+		return serviceTestHelper;
+	}
 
-  @Test
-  public void callRoot_withoutAuth_successfully() {
-    given()
-        .when()
-        .get(getRootUrl())
-        .then()
-        .statusCode(200);
-  }
+	@Test
+	public void callRoot_withoutAuth_successfully() {
+		given().when().get(serviceTestHelper.getRootUrl()).then().statusCode(200);
+	}
 
-  @Test
-  public void callAdmin_withoutBasicAuth_successfully() {
-    given()
-        .contentType(ContentType.JSON)
-        .when()
-        .get(getAdminUrl())
-        .then()
-        .statusCode(200);
-  }
+	@Test
+	public void callAdmin_withoutBasicAuth_successfully() {
+		given().contentType(ContentType.JSON).when().get(getServiceTestHelper().getAdminUrl()).then().statusCode(200);
+	}
 
-  @Test
-  public void callAdmin_withLegacyAuthHeader_headerIgnoredBackwardsCompatible() {
-    given()
-        .contentType(ContentType.JSON)
-        .header(X_AUTH_BASIC, X_AUTH_BASIC_VALUE)
-        .when()
-        .get(getAdminUrl())
-        .then()
-        .statusCode(200);
-  }
+	@Test
+	public void callAdmin_withLegacyAuthHeader_headerIgnoredBackwardsCompatible() {
+		given().contentType(ContentType.JSON).header(X_AUTH_BASIC, X_AUTH_BASIC_VALUE).when()
+				.get(getServiceTestHelper().getAdminUrl()).then().statusCode(200);
+	}
 }

--- a/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/CommonProperties.java
+++ b/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/CommonProperties.java
@@ -11,7 +11,7 @@ public class CommonProperties {
   public static final String SERVICE_PASSWORD = getPropertyOrEnv("auth.password", "SERVICE_PASSWORD");
   public static final String SERVICE_BASE_URL = System.getProperty("service.base.url", "http://localhost:4000");
 
-  private static String getPropertyOrEnv(String property, String envKey) {
+  public static String getPropertyOrEnv(String property, String envKey) {
     String value = System.getProperty(property);
     if (StringUtils.isEmpty(value)) {
       value = System.getenv(envKey);

--- a/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/ServiceTestHelper.java
+++ b/common-security-tests/src/main/java/uk/gov/defra/tracesx/common/security/tests/ServiceTestHelper.java
@@ -1,0 +1,60 @@
+package uk.gov.defra.tracesx.common.security.tests;
+
+import static uk.gov.defra.tracesx.common.security.tests.jwt.JwtConstants.BEARER;
+
+import java.util.function.Supplier;
+import org.apache.commons.lang3.StringUtils;
+
+/** Override this class for additional paths in service specific tests. */
+public class ServiceTestHelper {
+
+  public static final String AUTHORIZATION = "Authorization";
+
+  public ServiceTestHelper() {
+    assertNotNullOrEmpty(getServiceUsername(), "Username is empty");
+    assertNotNullOrEmpty(getServicePassword(), "Password is empty");
+    assertNotNullOrEmpty(getServiceBaseUrl(), "Url is empty");
+  }
+
+  private void assertNotNullOrEmpty(String value, String message) {
+    if (StringUtils.isBlank(value)) {
+      throw new NullPointerException(message);
+    }
+  }
+
+  public String getJwtAuthHeaderName() {
+    return AUTHORIZATION;
+  }
+
+  public String getJwtTokenHeaderValue(String token) {
+    return BEARER + token;
+  }
+
+  public String getServiceUsername() {
+    return CommonProperties.SERVICE_USERNAME;
+  }
+
+  public String getServicePassword() {
+    return CommonProperties.SERVICE_PASSWORD;
+  }
+
+  protected String getServiceBaseUrl() {
+    return CommonProperties.SERVICE_BASE_URL;
+  }
+
+  public String getRootUrl() {
+    return getServiceBaseUrl() + "/";
+  }
+
+  protected String getAdminUrl() {
+    return getServiceBaseUrl() + "/admin";
+  }
+
+  public String getUrl(String path) {
+    return getServiceBaseUrl() + path;
+  }
+
+  protected String getResourceUrl(Supplier<String> resourceRootSupplier, String path) {
+    return getUrl(resourceRootSupplier.get() + path);
+  }
+}


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | marcus bond (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-common-security](https://giteux.azure.defra.cloud/imports/spring-boot-common-security) |
> | **GitLab Merge Request** | [MTA-4763: Refactor of common security to...](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/4) |
> | **GitLab MR Number** | [4](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/4) |
> | **Date Originally Opened** | Thu, 4 Apr 2019 |
> | **Approved on GitLab by** | ian homer (WORTH SYSTEMS), matt dooner (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

Reconfigured HTTP security to provide explicit anonymous access to root and admin urls and expect all others to be secure; this removes the need to configire secure path in each service.

Added further functionality to the common testing support to reduce code duplication when porting tests and to assist in keeping a consistent approach