### PR TITLE
IMTA-6780: Set the sonar properties to report code coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,5 +5,4 @@ javaLibraryPipeline {
    SONARQUBE_PROJECT_NAME = "Imports-spring-boot-common-security"
    SERVICE_VERSION = "1.0"
    SELENIUM_BRANCH = "master"
-   JAVA_VERSION = "11"
 }

--- a/common-security-config/pom.xml
+++ b/common-security-config/pom.xml
@@ -124,6 +124,10 @@
           <suppressionsLocation>../checkstyle-suppressions.xml</suppressionsLocation>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/common-security-tests/pom.xml
+++ b/common-security-tests/pom.xml
@@ -62,6 +62,10 @@
           <suppressionsLocation>../checkstyle-suppressions.xml</suppressionsLocation>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,7 @@
     <nimbus.version>6.8</nimbus.version>
     <rest-assured.version>3.3.0</rest-assured.version>
     <spring.security.jwt.version>1.0.10.RELEASE</spring.security.jwt.version>
+    <jacoco.maven.plugin.version>0.8.4</jacoco.maven.plugin.version>
   </properties>
 
   <scm>
@@ -124,6 +125,49 @@
           <execution>
             <goals>
               <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>${jacoco.maven.plugin.version}</version>
+        <configuration>
+          <excludes>
+            <exclude>**/traceswsns/**/*</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>default-prepare-agent</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>default-check</id>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <rule implementation="org.jacoco.maven.RuleConfiguration">
+                  <element>BUNDLE</element>
+                  <limits>
+                    <limit implementation="org.jacoco.report.check.Limit">
+                      <counter>LINE</counter>
+                      <value>COVEREDRATIO</value>
+                    </limit>
+                  </limits>
+                </rule>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>report-agent</id>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>

--- a/runJunit.sh
+++ b/runJunit.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
-mvn test -f pom.xml
+export JAVA_HOME=$JAVA_HOME_11
+mvn clean test jacoco:report -f pom.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,14 @@
 sonar.projectKey=Imports-SpringBoot-CommonSecurity
 
-#By default include everything, use specific exclusions
-sonar.exclusions=common-security-config/src/main/resources/**,common-security-config/src/test/**,
-sonar.coverage.exclusions=**
-sonar.java.binaries=.
-sonar.sources=.
-sonar.java.source=1.8
+#List of module identifiers
+sonar.modules=common-security-config,common-security-tests
+
+sonar.java.binaries=target/classes
+sonar.java.test.binaries=target/test-classes
+sonar.tests=src/test/java
+sonar.sources=src/main/java
+sonar.java.source=11
+sonar.sourceEncoding=UTF-8
+sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/jacoco.xml
+sonar.dynamicAnalysis=reuseReports
+sonar.junit.reportPaths=target/surefire-reports


### PR DESCRIPTION
> [!NOTE]
> This pull request was migrated from GitLab
>
> |      |      |
> | ---- | ---- |
> | **Original Author** | marcus bond (KAINOS) |
> | **GitLab Project** | [imports/spring-boot-common-security](https://giteux.azure.defra.cloud/imports/spring-boot-common-security) |
> | **GitLab Merge Request** | [IMTA-6780: Set the sonar properties to r...](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/27) |
> | **GitLab MR Number** | [27](https://giteux.azure.defra.cloud/imports/spring-boot-common-security/merge_requests/27) |
> | **Date Originally Opened** | Thu, 12 Mar 2020 |
> | **Approved on GitLab by** | Ghost User, daniel brennan (KAINOS), dominik henjes (KAINOS) |
> |      |      |
>
> This merge request was originally **merged** on GitLab

## Original Description

IMTA-6780: Set the sonar properties to report code coverage

https://eaflood.atlassian.net/browse/IMTA-6780
